### PR TITLE
Replace © with ® in revit readme

### DIFF
--- a/Autodesk/Revit/README.md
+++ b/Autodesk/Revit/README.md
@@ -1,5 +1,5 @@
 # Rhino Inside Revit
-The Rhino Inside © technology allows Rhino and Grasshopper to be embedded within other products.
+The Rhino Inside® technology allows Rhino and Grasshopper to be embedded within other products.
 
 This folder contains a sample project that demonstrates:
 


### PR DESCRIPTION
Noticed this copyright symbol. Should it be a registration mark? Do we need to use ® everywhere?