### PR TITLE
Python verison support update due to pythonnet

### DIFF
--- a/CPython/README.md
+++ b/CPython/README.md
@@ -6,7 +6,7 @@ Embed Rhino in CPython
 ## Requirements:
 - Rhino 7
 - Windows
-- 64 bit version of CPython (2.7, 3.3, 3.4, 3.5, 3.6)
+- 64 bit version of CPython (2.7, 3.5, 3.6)
 
 ## How to use
 ```


### PR DESCRIPTION
Hi,
I tried to install using 3.4 as per listed in the support of the Cpython readme, but it turns out to not work because pythonnet install fails.
I have located that pythonnet have dropped some of the support of the python 3 versions and would like to show this on the readme.
https://github.com/pythonnet/pythonnet/commit/f544adc4076b1c5530896a19e2a3fbf7b238c754

Thanks,
kkshmz