### PR TITLE
Migrated DotNet projects to use Package Reference

### DIFF
--- a/DotNet/EtoApp/EtoApp.csproj
+++ b/DotNet/EtoApp/EtoApp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -42,7 +42,6 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainForm.cs" />
@@ -55,33 +54,19 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\Eto.dll</HintPath>
-    </Reference>
-    <Reference Include="Eto.Wpf, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoWindows.7.0.19274.12465-wip\lib\net45\Eto.Wpf.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="Rhino.UI, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\Rhino.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoCommon, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\RhinoCommon.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoWindows, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoWindows.7.0.19274.12465-wip\lib\net45\RhinoWindows.dll</HintPath>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="RhinoCommon">
+      <Version>7.0.19274.12465-wip</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="RhinoWindows">
+      <Version>7.0.19274.12465-wip</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets" Condition="Exists('packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets'))" />
-    <Error Condition="!Exists('packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets'))" />
-  </Target>
-  <Import Project="packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets" Condition="Exists('packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets')" />
 </Project>

--- a/DotNet/EtoApp/EtoApp.csproj
+++ b/DotNet/EtoApp/EtoApp.csproj
@@ -61,11 +61,11 @@
   <ItemGroup>
     <PackageReference Include="RhinoCommon">
       <Version>7.0.19274.12465-wip</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="RhinoWindows">
       <Version>7.0.19274.12465-wip</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DotNet/EtoApp/packages.config
+++ b/DotNet/EtoApp/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="RhinoCommon" version="7.0.19274.12465-wip" targetFramework="net472" />
-  <package id="RhinoWindows" version="7.0.19274.12465-wip" targetFramework="net472" />
-</packages>

--- a/DotNet/RhinoInside/RhinoInside.csproj
+++ b/DotNet/RhinoInside/RhinoInside.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <PackageReference Include="RhinoCommon">
       <Version>7.0.19274.12465-wip</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DotNet/RhinoInside/RhinoInside.csproj
+++ b/DotNet/RhinoInside/RhinoInside.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -35,15 +35,6 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\Eto.dll</HintPath>
-    </Reference>
-    <Reference Include="Rhino.UI, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\Rhino.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoCommon, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\RhinoCommon.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -58,14 +49,10 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="RhinoCommon">
+      <Version>7.0.19274.12465-wip</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets'))" />
-  </Target>
-  <Import Project="packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets" Condition="Exists('packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets')" />
-</Project>
+  </Project>

--- a/DotNet/RhinoInside/packages.config
+++ b/DotNet/RhinoInside/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="RhinoCommon" version="7.0.19274.12465-wip" targetFramework="net45" />
-</packages>

--- a/DotNet/WinFormsApp/WinFormsApp.csproj
+++ b/DotNet/WinFormsApp/WinFormsApp.csproj
@@ -36,21 +36,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\Eto.dll</HintPath>
-    </Reference>
-    <Reference Include="Eto.Wpf, Version=2.5.0.0, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoWindows.7.0.19274.12465-wip\lib\net45\Eto.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="Rhino.UI, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\Rhino.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoCommon, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.7.0.19274.12465-wip\lib\net45\RhinoCommon.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoWindows, Version=7.0.19274.12460, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoWindows.7.0.19274.12465-wip\lib\net45\RhinoWindows.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -84,7 +69,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -96,7 +80,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RhinoInside\RhinoInside.csproj">
@@ -104,14 +90,15 @@
       <Name>RhinoInside</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="RhinoCommon">
+      <Version>7.0.19274.12465-wip</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="RhinoWindows">
+      <Version>7.0.19274.12465-wip</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets" Condition="Exists('packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\RhinoCommon.7.0.19274.12465-wip\build\net45\RhinoCommon.targets'))" />
-    <Error Condition="!Exists('packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets'))" />
-  </Target>
-  <Import Project="packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets" Condition="Exists('packages\RhinoWindows.7.0.19274.12465-wip\build\net45\RhinoWindows.targets')" />
 </Project>

--- a/DotNet/WinFormsApp/WinFormsApp.csproj
+++ b/DotNet/WinFormsApp/WinFormsApp.csproj
@@ -93,11 +93,11 @@
   <ItemGroup>
     <PackageReference Include="RhinoCommon">
       <Version>7.0.19274.12465-wip</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
     </PackageReference>
     <PackageReference Include="RhinoWindows">
       <Version>7.0.19274.12465-wip</Version>
-      <ExcludeAssets>runtime</ExcludeAssets>
+      <IncludeAssets>compile; build</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DotNet/WinFormsApp/packages.config
+++ b/DotNet/WinFormsApp/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="RhinoCommon" version="7.0.19274.12465-wip" targetFramework="net472" />
-  <package id="RhinoWindows" version="7.0.19274.12465-wip" targetFramework="net472" />
-</packages>


### PR DESCRIPTION
Migrated the DotNet projects to use Package Reference according to these steps: https://docs.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference#migration-steps

The only other step is to ensure these dependencies do not end up in the build folder by adding `<IncludeAssets>compile;build</IncludeAssets>`. This has to be done manually (once) to each csproj and each package. More info on that: https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets

Projects were tested and function in the same manner as before the changes in this PR.