### PR TITLE
Actions can chain now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,8 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
     steps:
       - uses: kenhowardpdx/auto-merge-action@v1
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: windows-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PAT_ACTION_TOKEN }}
     steps:
       - uses: kenhowardpdx/auto-merge-action@v1
 


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.