### PR TITLE
Bump dependencies to 9.0.25350.305-wip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [9.0.10]
+- Updated rhino and grasshopper dependencies to 9.0.25350.305-wip
+
 ## [9.0.9]
 - Allow resolving Microsoft.macOS assembly
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,19 +17,13 @@
     <UseWinForms>true</UseWinForms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(linux))">
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform(windows))">
     <TargetFrameworks>net9.0</TargetFrameworks>
-    <!-- Linux can only work with this version of the GH and Rhinocommon nuget packages for now -->
-    <RhinoAPIVersion>9.0.25051.305-wip</RhinoAPIVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform(linux))">
-    <!-- Not Linux -->
-    <RhinoAPIVersion>9.0.25252.12305-wip</RhinoAPIVersion>
   </PropertyGroup>
 
   <PropertyGroup>
-    <RhinoInsideVersion>9.0.9</RhinoInsideVersion>
+    <RhinoInsideVersion>9.0.10</RhinoInsideVersion>
+    <RhinoAPIVersion>9.0.25350.305-wip</RhinoAPIVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <CopyrightYear>2025</CopyrightYear>
     <RepositoryUrl>https://github.com/mcneel/Rhino.Inside.git</RepositoryUrl>


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.

- [x] Increased Version Number?
- [x] Updated CHANGELOG.md?
- [ ] Added tests for your changes?
- [ ] Notified project maintainers of this change and PR?
  - [ ] Rhino.Inside-CPython
  - [ ] Rhino.Compute
  - [x] Rhino.Testing