### PR TITLE
Version numbers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,13 +22,6 @@ jobs:
       - name: Update Version Numbers
         run: ./src/version/version.sh
 
-      - name: Commit version changes
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "Update version numbers" || echo "No changes to commit"
-          git push
-
   build:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,27 @@ env:
   RHINO_TOKEN: ${{ secrets.RHINO_TOKEN }}
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Update Version Numbers
+        run: ./src/version/version.sh
+
+      - name: Commit version changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -am "Update version numbers" || echo "No changes to commit"
+          git push
+
   build:
     runs-on: windows-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,5 @@ ASALocalRun/
 # Visual Studio Code settings
 .vscode
 .DS_Store
+
+src/version/version.cs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [9.0.26013.1000]
+- Added version number generation
+
 ## [9.0.10]
 - Updated rhino and grasshopper dependencies to 9.0.25350.305-wip
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RhinoInsideVersion>9.0.10</RhinoInsideVersion>
+    <RhinoInsideVersion>9.0.26013.1000</RhinoInsideVersion>
     <RhinoAPIVersion>9.0.25350.305-wip</RhinoAPIVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <CopyrightYear>2025</CopyrightYear>

--- a/src/RhinoInside/RhinoInside.csproj
+++ b/src/RhinoInside/RhinoInside.csproj
@@ -56,6 +56,6 @@
   </Choose>
 
   <Target Name="CopyPackage" AfterTargets="Pack">
-    <Copy SourceFiles="$(OutputPath)\$(PackageId).$(PackageVersion).nupkg" DestinationFolder="..\build" />
+    <Copy SourceFiles="$(OutputPath)$(PackageId).$(PackageVersion).nupkg" DestinationFolder="..\build" />
   </Target>
 </Project>

--- a/src/version/UpdateVersionNumbers.csproj
+++ b/src/version/UpdateVersionNumbers.csproj
@@ -1,0 +1,99 @@
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.0.4">
+  <Import Project="build_dates.msbuild"/>
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="version.*.template" />
+  </ItemGroup>
+
+  <UsingTask TaskName="ReplaceInFile" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <FileName ParameterType="System.String" Required="True" />
+      <Pattern ParameterType="System.String" Required="True" />
+      <Replacement ParameterType="System.String" Required="True" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+  // 2017-06-15, Brian Gillespie:
+  // For some reason, MSBuild replaces all backslashes with forward slashes
+  // before calling the customer task, at least on Mac. This totally breaks
+  // regular expressions! A hack of a fix is to put them back, and hope nobody
+  // really meant to pass in forward slashes. What a drag!
+  Pattern = Pattern.Replace("/", "\\");
+  // Log.LogMessage(string.Format("{0} > {1}", Pattern, Replacement));
+  var f = File.ReadAllText(FileName);
+  var re = new Regex(Pattern);
+  var b = re.Replace(f, Replacement);
+  if (b != f) {
+    Log.LogMessage(string.Format("{0}: Replaced {1} > {2}", FileName, Pattern, Replacement));
+    File.WriteAllText(FileName, b);
+  }
+  ]]></Code>
+    </Task>
+  </UsingTask>
+
+
+  <!--
+  *********************************************************************
+  BUILD
+  *********************************************************************
+  -->
+  <Target Name="BuildVersion" BeforeTargets="BeforeBuild" DependsOnTargets="SetBuildDates">
+    <PropertyGroup>
+      <PreviousMajorVersion>$([MSBuild]::Subtract($(MajorVersion), 1))</PreviousMajorVersion>
+    </PropertyGroup>
+
+    <Message Text="$(BuildDate)" Importance="high"/>
+    <Message Text="**** Updating version numbers to $(BuildVersion) ****" />
+    <ItemGroup>
+      <SourceFileExtensions Include="cs" />
+    </ItemGroup>
+    <Copy SourceFiles="$(BuildRoot)\version\version.%(SourceFileExtensions.Identity).template"
+       DestinationFiles="$(BuildRoot)\version\version.%(SourceFileExtensions.Identity)"
+       Condition="!Exists('$(BuildRoot)\version\version.%(SourceFileExtensions.Identity)')  OR $([System.IO.File]::GetLastWriteTime('$(BuildRoot)\version\version.%(SourceFileExtensions.Identity).template').Ticks) &gt; $([System.IO.File]::GetLastWriteTime('$(BuildRoot)\version\version.%(SourceFileExtensions.Identity)').Ticks)"
+       />
+
+    <Exec Command="git rev-parse HEAD &gt; .sha" Condition="$(OfficialBuild)=='true'" />
+    <ReadLinesFromFile File=".sha" Condition="$(OfficialBuild)=='true'" >
+      <Output TaskParameter="Lines" PropertyName="GitCurrentCommitSHA" />
+    </ReadLinesFromFile>
+    <Delete Files=".sha" Condition="$(OfficialBuild)=='true'" />
+
+    <!-- C# (version.cs) -->
+    <Message Text="------------- version.cs ----------------"/>
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="AssemblyVersion\(&quot;[\dx\.]+&quot;\)" Replacement="AssemblyVersion(&quot;$(BuildVersion)&quot;)" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" MAJOR_MINOR_VERSION_STRING\s*=\s*&quot;[\dx\.]+&quot;;" Replacement=" MAJOR_MINOR_VERSION_STRING = &quot;$(MajorVersion).$(MinorVersion)&quot;;" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" MAJOR_VERSION_STRING\s*=\s*&quot;[\dx\.]+&quot;;" Replacement=" MAJOR_VERSION_STRING = &quot;$(MajorVersion)&quot;;" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" VERSION_STRING\s*=\s*&quot;[\dx\.]+&quot;;" Replacement=" VERSION_STRING = &quot;$(BuildVersion)&quot;;" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" MAJOR_VERSION\s*=\s*[\dx]+;" Replacement=" MAJOR_VERSION = $(MajorVersion);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" MINOR_VERSION\s*=\s*[\dx]+;" Replacement=" MINOR_VERSION = $(MinorVersion);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="YEAR\s*=\s*[\dx]+;" Replacement="YEAR = $(BuildYear);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" MONTH\s*=\s*[\dx]+;" Replacement=" MONTH = $(BuildMonth);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern=" DAY_OF_MONTH\s*=\s*[\dx]+;" Replacement=" DAY_OF_MONTH = $(BuildDayOfMonth);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="HOUR\s*=\s*[\dx]+;" Replacement="HOUR = $(BuildHour);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="MINUTE\s*=\s*[\dx]+;" Replacement="MINUTE = $(BuildMinute);" />
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="USE_COMMERCIAL_LICENSE = .*;" Replacement="USE_COMMERCIAL_LICENSE = true;" Condition="$(BUILD_TYPE)==COMMERCIAL OR $(DEVELOPER_BUILD_TYPE)==COMMERCIAL"/>
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="USE_COMMERCIAL_LICENSE = .*;" Replacement="USE_COMMERCIAL_LICENSE = false;" Condition="$(BUILD_TYPE)!=COMMERCIAL AND $(DEVELOPER_BUILD_TYPE)!=COMMERCIAL"/>
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="PRE_RELEASE = .*;" Replacement="PRE_RELEASE = false;" Condition="$(BUILD_TYPE)==COMMERCIAL OR $(DEVELOPER_BUILD_TYPE)==COMMERCIAL"/>
+    <ReplaceInFile FileName="$(BuildRoot)\version\version.cs" Pattern="PRE_RELEASE = .*;" Replacement="PRE_RELEASE = true;" Condition="$(BUILD_TYPE)!=COMMERCIAL AND $(DEVELOPER_BUILD_TYPE)!=COMMERCIAL"/>
+  </Target>
+
+  <!--
+  *********************************************************************
+  CLEAN
+  *********************************************************************
+  -->
+  <Target Name="CleanVersion" AfterTargets="AfterClean">
+    <ItemGroup>
+      <DeleteFiles Include="$(BuildRoot)\version\version.cs" />
+    </ItemGroup>
+    <Delete Files="@(DeleteFiles)" />
+  </Target>
+</Project>

--- a/src/version/build_dates.msbuild
+++ b/src/version/build_dates.msbuild
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <!-- 
+  Properties are declared here, and set in SetBuildDates task, below
+  For details, see https://mcneel.myjetbrains.com/youtrack/issue/RH-52713
+  -->
+  <PropertyGroup>
+    <IsWindows>false</IsWindows>
+    <IsMac>false</IsMac>
+    <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+    <IsMac Condition="('$(MSBuildRuntimeType)' == 'Core' OR '$(MSBuildRuntimeType)' == 'Mono') AND $([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))">true</IsMac>
+
+    <BuildRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))</BuildRoot>
+    <!-- ToString("s") returns yyyy-MM-ddTHH:mm:ss in all locales -->
+    <BuildDate Condition="'$(BuildDate)'==''">default-build-date</BuildDate>
+    <MajorVersion Condition="'$(MajorVersion)'==''">9</MajorVersion>
+    <MinorVersion Condition="'$(MinorVersion)'==''">0</MinorVersion>
+    <DEVELOPER_BUILD_TYPE>WIP</DEVELOPER_BUILD_TYPE>
+    <DEVELOPER_BUILD_TYPE Condition="'$(MajorVersion)'=='8'">COMMERCIAL</DEVELOPER_BUILD_TYPE>
+    <BuildMonthName>XXX</BuildMonthName>
+    <BuildDayOfYear>X</BuildDayOfYear>
+    <BuildDayOfYearPadded>X</BuildDayOfYearPadded>
+    <BuildDayOfMonth>XXX</BuildDayOfMonth>
+    <BuildMonth>X</BuildMonth>
+    <BuildYear>X</BuildYear>
+    <BuildYearTwoDigit>XX</BuildYearTwoDigit>
+    <BuildHour>X</BuildHour>
+    <BuildMinute>X</BuildMinute>
+    <BuildBranchId>0</BuildBranchId>
+    <BuildDescription>X</BuildDescription>
+    <GitCurrentCommitSHA>X</GitCurrentCommitSHA>
+    <BuildVersion>X.X.X.X</BuildVersion>
+    <BuildVersionWithCommas>X,X,X,X</BuildVersionWithCommas>
+    <BuildDateSet Condition="'$(BuildDateSet)'==''">0</BuildDateSet>
+	<BuildDatesFileIncluded>true</BuildDatesFileIncluded>
+  </PropertyGroup>
+
+  <Target Name="SetBuildDates">
+    <PropertyGroup>
+      <IsWindows>false</IsWindows>
+      <IsMac>false</IsMac>
+      <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+      <IsMac Condition="('$(MSBuildRuntimeType)' == 'Core' OR '$(MSBuildRuntimeType)' == 'Mono') AND   $([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))">true</IsMac>
+    
+      <BuildRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..'))</BuildRoot>
+      <!-- ToString("s") returns yyyy-MM-ddTHH:mm:ss in all locales -->
+      <BuildDate Condition="('$(BuildDate)'=='' OR '$(BuildDate)'=='default-build-date') AND '$(FastIncrementalBuild)'!='true'">$([System.DateTime]::Now.ToString("s"))</BuildDate>
+      <BuildDate Condition="'$(FastIncrementalBuild)'=='true'">2011-11-11T11:11:11</BuildDate>
+      <MajorVersion Condition="'$(MajorVersion)'==''">7</MajorVersion>
+      <MinorVersion Condition="'$(MinorVersion)'==''">0</MinorVersion>
+      <BuildMonthName>$([System.DateTime]::Parse($(BuildDate)).ToString("MMM"))</BuildMonthName>
+      <BuildDayOfYear>$([System.DateTime]::Parse($(BuildDate)).DayOfYear)</BuildDayOfYear>
+      <BuildDayOfYearPadded>$([System.String]::Format('{0:000}', $([MSBuild]::Add($(BuildDayOfYear),0 ))))</BuildDayOfYearPadded>
+      <BuildDayOfMonth>$([System.DateTime]::Parse($(BuildDate)).ToString("dd"))</BuildDayOfMonth>
+      <BuildMonth>$([System.DateTime]::Parse($(BuildDate)).ToString("MM"))</BuildMonth>
+      <BuildYear>$([System.DateTime]::Parse($(BuildDate)).Year)</BuildYear>
+      <BuildYearTwoDigit>$([System.DateTime]::Parse($(BuildDate)).ToString("yy"))</BuildYearTwoDigit>
+      <BuildHour Condition="$(OfficialBuild)!='true'">01</BuildHour>
+      <BuildHour Condition="$(OfficialBuild)=='true'">$([System.DateTime]::Parse($(BuildDate)).ToString("HH"))</BuildHour>
+      <BuildMinute Condition="$(OfficialBuild)!='true'">00</BuildMinute>
+      <BuildMinute Condition="$(OfficialBuild)=='true'">$([System.DateTime]::Parse($(BuildDate)).ToString("mm"))</BuildMinute>
+    
+      <BuildBranchId>0</BuildBranchId>
+    
+      <BuildBranchId Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='COMMERCIAL' AND $(IsWindows)">1</BuildBranchId>
+      <BuildBranchId Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='COMMERCIAL' AND $(IsMac)">2</BuildBranchId>
+    
+      <BuildBranchId Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='BETA' AND $(IsWindows)">3</BuildBranchId>
+      <BuildBranchId Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='BETA' AND  $(IsMac)">4</BuildBranchId>
+    
+      <BuildBranchId Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='WIP' AND $(IsWindows)">5</BuildBranchId>
+      <BuildBranchId Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='WIP' AND  $(IsMac)">6</BuildBranchId>
+    
+      <BuildDescription>Private Developer Build</BuildDescription>
+      <BuildDescription Condition="$(OfficialBuild)=='true'">Public Build</BuildDescription>
+      <BuildDescription Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='WIP'">Rhino WIP</BuildDescription>
+      <BuildDescription Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='BETA'">Rhino $(MajorVersion) BETA</BuildDescription>
+      <BuildDescription Condition="$(OfficialBuild)=='true' AND $(BUILD_TYPE)=='COMMERCIAL'">Rhino $(MajorVersion)</BuildDescription>
+
+      <GitCurrentCommitSHA>0</GitCurrentCommitSHA>
+      <BuildVersion>$(MajorVersion).$(MinorVersion).$(BuildYearTwoDigit)$(BuildDayOfYearPadded).$(BuildHour)$(BuildMinute)$(BuildBranchId)</BuildVersion>
+      <BuildVersionWithCommas>$(BuildVersion.Replace('.',','))</BuildVersionWithCommas>
+      <BuildVersionWithCommas>$(BuildVersionWithCommas.Replace(',0',','))</BuildVersionWithCommas>
+      <BuildVersionWithCommas>$(BuildVersionWithCommas.Replace(',0',','))</BuildVersionWithCommas>
+      <BuildVersionWithCommas>$(BuildVersionWithCommas.Replace(',0',','))</BuildVersionWithCommas>
+      <BuildVersionWithCommas>$(BuildVersionWithCommas.Replace(',0',','))</BuildVersionWithCommas>
+      <BuildVersionWithCommas>$(BuildVersionWithCommas.Replace(',,',',0,'))</BuildVersionWithCommas>
+
+	  <BuildDateSet Condition="'$(BuildDateSet)' != 'true' ">true</BuildDateSet>
+    </PropertyGroup>
+    <Message Text="--------------------===========&gt;&gt;&gt; BUILD DATE SET: $(BuildDate) &lt;&lt;&lt;============------------------"/>
+    <Message Text="OfficialBuild        = $(OfficialBuild)" />
+    <Message Text="BUILD_TYPE           = $(BUILD_TYPE)" />
+    <Message Text="DEVELOPER_BUILD_TYPE = $(DEVELOPER_BUILD_TYPE)" />
+    <Message Text="BuildDescription     = $(BuildDescription)" />
+    <Message Text="BuildVersion         = $(BuildVersion)" />
+  </Target>
+</Project>

--- a/src/version/version.cs.props
+++ b/src/version/version.cs.props
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+***********************************************************************************************
+version.cs.props
+
+Import this for sdk-style projects to include copyright and version information.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Company>Robert McNeel &amp; Associates</Company>
+    <Copyright>Copyright (C) 1993-2022, Robert McNeel &amp; Associates. All Rights Reserved.</Copyright>
+    <Authors>Robert McNeel &amp; Associates</Authors>
+    
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+  </PropertyGroup>
+  <Target Name="IncludeVersionInBuild" BeforeTargets="BeforeBuild">
+    <!-- 
+      Include version.cs before the build starts, which should guarantee that it exists as UpdateVersionNumbers 
+      should have been built before this happens.
+      -->
+    <ItemGroup>
+      <Compile Include="$(MSBuildThisFileDirectory)version.cs" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/version/version.cs.template
+++ b/src/version/version.cs.template
@@ -1,0 +1,31 @@
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// Version.cs controls all version numbers for all plug-ins and other C# projects
+// that ship with Rhino 6.
+
+namespace RhinoVersion {
+
+static class RhinoBuildConstants
+{
+  // To update version numbers, edit build_dates.msbuild
+  public const string VERSION_STRING = "x.x.0.0";
+  public const string MAJOR_MINOR_VERSION_STRING = "x.x";
+  public const string MAJOR_VERSION_STRING = "x";
+  public const int MAJOR_VERSION = x;
+  public const int MINOR_VERSION = x;
+  public const int YEAR = 2015;
+  public const int MONTH = 10;
+  public const int DAY_OF_MONTH = 14;
+  public const int HOUR = 13;
+  public const int MINUTE = 19;
+  public const bool PRE_RELEASE = true;
+
+}
+
+}
+

--- a/src/version/version.sh
+++ b/src/version/version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# navigate to script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# generate version numbers
+dotnet build UpdateVersionNumbers.csproj --configuration ReleaseDebuggable -restore -m
+
+# get version
+VERSION_STRING=$(grep 'public const string VERSION_STRING' version.cs | sed -E 's/.*"([^"]+)".*/\1/')
+
+# Remove leading zeros from the last segment
+VERSION_STRING_FIXED=$(echo "$VERSION_STRING" | sed -E 's/(.*\.)(0*)([0-9]+)$/\1\3/')
+echo "$VERSION_STRING" " → " "$VERSION_STRING_FIXED"
+
+# set version in Directory.Build.props
+sed -i 's|<RhinoInsideVersion>.*</RhinoInsideVersion>|<RhinoInsideVersion>'"$VERSION_STRING_FIXED"'</RhinoInsideVersion>|' ../Directory.Build.props


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.

- [x] Increased Version Number?
- [x] Updated CHANGELOG.md?
- [ ] Added tests for your changes?
- [x] Notified project maintainers of this change and PR?
  - [ ] Rhino.Inside-CPython
  - [ ] Rhino.Compute
  - [ ] Rhino.Testing