### PR TITLE
pass version to build step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Update Version Numbers
         run: ./src/version/version.sh
+
       - name: Upload versioned files
         uses: actions/upload-artifact@v4
         with:
@@ -54,10 +55,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
+      - name: List files after download
+        shell: pwsh
+        run: Get-ChildItem -Recurse
+      
       - name: Download versioned files
         uses: actions/download-artifact@v4
         with:
           name: version-files
+          path: src/
 
       - name: Overwrite versioned files
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,12 @@ jobs:
 
       - name: Update Version Numbers
         run: ./src/version/version.sh
+      - name: Upload versioned files
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-files
+          path: |
+            src/Directory.Build.props
 
   build:
     runs-on: windows-latest
@@ -46,6 +52,15 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Download versioned files
+        uses: actions/download-artifact@v4
+        with:
+          name: version-files
+
+      - name: Overwrite versioned files
+        run: |
+          cp version-files/* src/
 
       - name: Build
         run: dotnet build -c Release src/RhinoInside.sln

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ jobs:
 
   build:
     runs-on: windows-latest
+    needs: [ version ]
     steps:
       - name: Get token
         if: (github.event_name == 'pull_request')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,14 +59,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: version-files
-
-      - name: List files after download
-        shell: pwsh
-        run: Get-ChildItem -Recurse
-
-      - name: Overwrite versioned files
-        run: |
-          Copy-Item "version-files/*" "src/" -Force
+          path: src/
 
       - name: Build
         run: dotnet build -c Release src/RhinoInside.sln

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,15 +54,15 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
-      
-      - name: List files after download
-        shell: pwsh
-        run: Get-ChildItem -Recurse
-      
+  
       - name: Download versioned files
         uses: actions/download-artifact@v4
         with:
           name: version-files
+
+      - name: List files after download
+        shell: pwsh
+        run: Get-ChildItem -Recurse
 
       - name: Overwrite versioned files
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: version-files
-          path: src/
 
       - name: Overwrite versioned files
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Overwrite versioned files
         run: |
-          cp version-files/* src/
+          Copy-Item "version-files/*" "src/" -Force
 
       - name: Build
         run: dotnet build -c Release src/RhinoInside.sln


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.
