### PR TITLE
Net10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [9.0.26013.16420]
+- Added .net 10 targets
+
 ## [9.0.26013.1000]
 - Added version number generation
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     <!-- Rhino.Inside for Rhino >= 9 is gonna support only the latest netcore version supported by Rhino -->
     <!-- This is to avoid conflict between dll versions Rhino is built agaist, with dlls or older dotnet runtime -->
     <!-- If you absolutely need this to work, talk to curtis @ mcneel -->
-    <TargetFrameworks>net48;net9.0;net9.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net9.0;net9.0-windows;net10.0;net10.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.EndsWith('windows'))">
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform(windows))">
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/RhinoInside/Resolver_NetCore.cs
+++ b/src/RhinoInside/Resolver_NetCore.cs
@@ -137,6 +137,8 @@ namespace RhinoInside
         if (TryGetAssemblyPathFromName($"dotnetstart.{version}", out dotnetstartLib))
           break;
       }
+      if (dotnetstartLib is null)
+        throw new RhinoInsideInitializationException($"Could not find dotnetstart dll for .NET {Environment.Version.Major} or earlier in '{RhinoSystemDirectory}'");
       var assembly = context.LoadFromAssemblyPath(dotnetstartLib);
       var programType = assembly?.GetType("dotnetstart.DotNetInitialization");
       var method = programType?.GetMethod("Start");

--- a/src/RhinoInside/Resolver_NetCore.cs
+++ b/src/RhinoInside/Resolver_NetCore.cs
@@ -124,8 +124,19 @@ namespace RhinoInside
 
     static void ExecuteLoadProc(AssemblyLoadContext context)
     {
-      int dotnetMajor = Environment.Version.Major;
-      TryGetAssemblyPathFromName($"dotnetstart.{dotnetMajor}", out string dotnetstartLib);
+      // Revert to this once dotnetstart.10.dll is available.
+      // int dotnetMajor = Environment.Version.Major;
+      // TryGetAssemblyPathFromName($"dotnetstart.{dotnetMajor}", out string dotnetstartLib);
+
+      // 2026.03.25 - Luis Fraguada
+      // Temp workaround to build against .net10 and find dotnetstart.9.dll until dotnetstart.10.dll is available. 
+      // We should remove this loop and directly look for dotnetstart.10.dll once it's available.
+      string dotnetstartLib = null;
+      for (int version = Environment.Version.Major; version >= 8; --version)
+      {
+        if (TryGetAssemblyPathFromName($"dotnetstart.{version}", out dotnetstartLib))
+          break;
+      }
       var assembly = context.LoadFromAssemblyPath(dotnetstartLib);
       var programType = assembly?.GetType("dotnetstart.DotNetInitialization");
       var method = programType?.GetMethod("Start");


### PR DESCRIPTION
## Note to Developer

Pull-requests on base `rhino-*.x` branches trigger build and test actions. After the build and test actions are passed, pull-request is automatically merged into the base branch and new merge-down pull-request is created on the next `rhino-*.x` branch by major version.

To publish NuGet packages created by the build action, select the *build* action and run it manually on the base `rhino-*.x` branch.

- [x] Increased Version Number?
- [x] Updated CHANGELOG.md?
- [ ] Added tests for your changes?
- [ ] Notified project maintainers of this change and PR?
  - [ ] Rhino.Inside-CPython
  - [x] Rhino.Compute
  - [ ] Rhino.Testing